### PR TITLE
chore: adapt multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-FROM golang:1.23.4-alpine
+FROM golang:1.23.4-alpine AS builder
 
-WORKDIR /
+WORKDIR /app
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o exporter ./cmd/exporter
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o exporter ./cmd/exporter
+
+FROM alpine:latest
+
+WORKDIR /
+
+COPY --from=builder /app/exporter .
 
 ENV PORT=9113
 EXPOSE 9113


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

adapt mulitistage build for reducing docker image size
`486.7MB -> 16.4MB`
<img width="795" alt="image" src="https://github.com/user-attachments/assets/3a365f96-6152-428e-947b-c5ed4ff65c49" />


<!-- Issue number if applicable -->
#### Link to tracking issue

Fixes # https://github.com/Ecube-Labs/kafka-connect-exporter/issues/2