### PR TITLE
Refactor: Separate collector and exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ You can also run the exporter using Docker Compose.
 1. Create a docker-compose.yml file with the following content:
 
 ```yml
-version: "3.7"
 services:
   kafka-connect-exporter:
     image: ecubelabs/kafka-connect-exporter:latest

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,13 +1,49 @@
 package main
 
 import (
+	"context"
+	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/collector"
 	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
+	exporter "github.com/Ecube-Labs/kafka-connect-exporter/internal/exporter/prometheus"
 	"github.com/Ecube-Labs/kafka-connect-exporter/internal/server"
+	applicationError "github.com/Ecube-Labs/kafka-connect-exporter/pkg/application-error"
 	"github.com/Ecube-Labs/kafka-connect-exporter/pkg/logger"
 )
 
 func main() {
-	server := server.New(config.Port)
+	collector := collector.New(&http.Client{Timeout: 10 * time.Second})
+	exporter := exporter.New(collector)
+
+	mux := http.NewServeMux()
+	mux.Handle(config.MetricsEndpoint, exporter.Handler())
+	mux.HandleFunc(config.HealthCheckEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	server := server.New(config.Port, mux)
 	logger.Log("info", "Starting Kafka Connect Exporter")
-	server.Run()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		if err := server.Run(); err != nil {
+			logger.Log("error", applicationError.UnWrap(err).Stack)
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Log("info", "Server is shutting down...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		logger.Log("error", applicationError.UnWrap(err).Stack)
+	}
 }

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -1,25 +1,13 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"net/http"
-
-	"github.com/Ecube-Labs/kafka-connect-exporter/internal/collector"
 	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/server"
 	"github.com/Ecube-Labs/kafka-connect-exporter/pkg/logger"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func main() {
-	prometheus.MustRegister(collector.New())
-	http.Handle(config.MetricsEndpoint, promhttp.Handler())
-	http.HandleFunc(config.HealthCheckEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	})
-
+	server := server.New(config.Port)
 	logger.Log("info", "Starting Kafka Connect Exporter")
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", config.Port), nil))
+	server.Run()
 }

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -6,46 +6,22 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
-	"time"
 
-	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
 	applicationError "github.com/Ecube-Labs/kafka-connect-exporter/pkg/application-error"
-	"github.com/Ecube-Labs/kafka-connect-exporter/pkg/logger"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
-// A struct that implements the prometheus.Collector interface.
-// https://github.com/prometheus/client_golang/blob/7b39d0144166aa94cc8ce4125bcb3b0da89aad5e/prometheus/collector.go#L27
-type collector struct {
-	client             *http.Client
-	descUnassigned     *prometheus.Desc
-	descRunning        *prometheus.Desc
-	descFailed         *prometheus.Desc
-	descPaused         *prometheus.Desc
-	descTaskCount      *prometheus.Desc
-	descConnectorCount *prometheus.Desc
+type Collector struct {
+	client *http.Client
 }
 
-func New() *collector {
-	labels := []string{"connector", "host"}
-	prefix := "kafka_connect_connector"
-
-	return &collector{
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-		descRunning:        prometheus.NewDesc(prefix+"_running_total", "Total number of tasks in the `RUNNING` state", labels, nil),
-		descFailed:         prometheus.NewDesc(prefix+"_failed_total", "Total number of tasks in the `FAILED` state (e.g., due to exceptions reported in status)", labels, nil),
-		descPaused:         prometheus.NewDesc(prefix+"_paused_total", "Total number of paused tasks for the Kafka Connect connector", labels, nil),
-		descUnassigned:     prometheus.NewDesc(prefix+"_unassigned_total", "Total number of tasks in the `Unassigned` state (i.e., not assigned to any worker.)", labels, nil),
-		descTaskCount:      prometheus.NewDesc(prefix+"_task_total", "Total number of tasks for the Kafka Connect connector", labels, nil),
-		descConnectorCount: prometheus.NewDesc(prefix+"_total", "Total number of tasks for the connector.", []string{"host"}, nil),
+func New(client *http.Client) *Collector {
+	return &Collector{
+		client: client,
 	}
 }
 
 // Get a list of kafka connect connectors from the given host
-func (c *collector) getConnectors(host string) ([]string, error) {
+func (c *Collector) GetConnectors(host string) ([]string, error) {
 	response, err := c.client.Get(fmt.Sprintf("%s/connectors", host))
 	if err != nil {
 		return nil, applicationError.New(http.StatusInternalServerError, err.Error(), "")
@@ -69,7 +45,7 @@ func (c *collector) getConnectors(host string) ([]string, error) {
 }
 
 // Retrieve the status of a kafka connect connector
-func (c *collector) getConnectorStatus(host string, connector string) (*connectorStatus, error) {
+func (c *Collector) GetConnectorStatus(host string, connector string) (*connectorStatus, error) {
 	encodedConnectorName := url.PathEscape(connector)
 	response, err := c.client.Get(fmt.Sprintf("%s/connectors/%s/status", host, encodedConnectorName))
 	if err != nil {
@@ -91,98 +67,4 @@ func (c *collector) getConnectorStatus(host string, connector string) (*connecto
 	}
 
 	return &status, nil
-}
-
-// Describe is a no-op, because the collector dynamically allocates metrics.
-// https://github.com/prometheus/client_golang/blob/v1.9.0/prometheus/collector.go#L28-L40
-func (c *collector) Describe(_ chan<- *prometheus.Desc) {}
-
-func (c *collector) Collect(ch chan<- prometheus.Metric) {
-	var wg sync.WaitGroup
-
-	// collect metrics for each kafka connect host
-	for _, host := range config.KafkaConnectHosts {
-		wg.Add(1)
-
-		go func(h string) {
-			defer wg.Done()
-
-			connectors, err := c.getConnectors(h)
-			if err != nil {
-				logger.Log("error", applicationError.UnWrap(err).Stack)
-				return
-			}
-			ch <- prometheus.MustNewConstMetric(c.descConnectorCount, prometheus.GaugeValue, float64(len(connectors)), h)
-
-			for _, connector := range connectors {
-				status, err := c.getConnectorStatus(h, connector)
-				if err != nil {
-					logger.Log("error", applicationError.UnWrap(err).Stack)
-					continue
-				}
-
-				var unAssignedTaskCount int
-				var runningTaskCount int
-				var pausedTaskCount int
-				var failedTaskCount int
-
-				for _, task := range status.Tasks {
-					switch task.State {
-					case "RUNNING":
-						runningTaskCount++
-					case "PAUSED":
-						pausedTaskCount++
-					case "FAILED":
-						failedTaskCount++
-					default:
-						unAssignedTaskCount++
-					}
-				}
-				metric := ConnectorStatusMetric{
-					UnAssignedTaskCount: unAssignedTaskCount,
-					RunningTaskCount:    runningTaskCount,
-					PausedTaskCount:     pausedTaskCount,
-					FailedTaskCount:     failedTaskCount,
-					TotalTaskCount:      len(status.Tasks),
-				}
-
-				ch <- prometheus.MustNewConstMetric(
-					c.descUnassigned,
-					prometheus.GaugeValue,
-					float64(metric.UnAssignedTaskCount),
-					connector, h,
-				)
-
-				ch <- prometheus.MustNewConstMetric(
-					c.descRunning,
-					prometheus.GaugeValue,
-					float64(metric.RunningTaskCount),
-					connector, h,
-				)
-
-				ch <- prometheus.MustNewConstMetric(
-					c.descFailed,
-					prometheus.GaugeValue,
-					float64(metric.FailedTaskCount),
-					connector, h,
-				)
-
-				ch <- prometheus.MustNewConstMetric(
-					c.descPaused,
-					prometheus.GaugeValue,
-					float64(metric.PausedTaskCount),
-					connector, h,
-				)
-
-				ch <- prometheus.MustNewConstMetric(
-					c.descTaskCount,
-					prometheus.GaugeValue,
-					float64(metric.TotalTaskCount),
-					connector, h,
-				)
-			}
-		}(host)
-	}
-
-	wg.Wait()
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -6,20 +6,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNew(t *testing.T) {
 	t.Run("Should return a new collector", func(t *testing.T) {
-		collector := New()
+		collector := New(http.DefaultClient)
 		assert.NotNil(t, collector)
-	})
-	t.Run("Should return a collector implementing the prometheus.Collector interface", func(t *testing.T) {
-		collector := New()
-		_, ok := interface{}(collector).(prometheus.Collector)
-		assert.True(t, ok)
 	})
 }
 
@@ -41,10 +34,9 @@ func TestGetConnectors(t *testing.T) {
 			},
 		}
 
-		collector := New()
-		collector.client = &http.Client{Transport: roundTripper}
+		collector := New(&http.Client{Transport: roundTripper})
 
-		connectors, err := collector.getConnectors("test")
+		connectors, err := collector.GetConnectors("test")
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"connector1", "connector2"}, connectors)
 	})
@@ -58,10 +50,9 @@ func TestGetConnectors(t *testing.T) {
 				return response.Result(), nil
 			})}
 
-		collector := New()
-		collector.client = &http.Client{Transport: roundTripper}
+		collector := New(&http.Client{Transport: roundTripper})
 
-		connectors, err := collector.getConnectors("test")
+		connectors, err := collector.GetConnectors("test")
 		assert.Nil(t, connectors)
 		assert.NotNil(t, err)
 		assert.Equal(t, `Failed to get connectors. status: 444, body: "Internal Server Error"`, err.Error())
@@ -95,10 +86,9 @@ func TestGetConnectorStatus(t *testing.T) {
 			},
 		}
 
-		collector := New()
-		collector.client = &http.Client{Transport: roundTripper}
+		collector := New(&http.Client{Transport: roundTripper})
 
-		status, err := collector.getConnectorStatus("test", "connector1")
+		status, err := collector.GetConnectorStatus("test", "connector1")
 		assert.Nil(t, err)
 		assert.Equal(t, &connectorStatus{Name: "connector1", Connector: struct {
 			State    string `json:"state"`
@@ -114,94 +104,11 @@ func TestGetConnectorStatus(t *testing.T) {
 				response.Write([]byte(`"Internal Server Error"`))
 				return response.Result(), nil
 			})}
+		collector := New(&http.Client{Transport: roundTripper})
 
-		collector := New()
-		collector.client = &http.Client{Transport: roundTripper}
-
-		connectors, err := collector.getConnectorStatus("test", "connector1")
-		assert.Nil(t, connectors)
+		status, err := collector.GetConnectorStatus("test", "connector1")
+		assert.Nil(t, status)
 		assert.NotNil(t, err)
 		assert.Equal(t, `Failed to get connector status. status: 444, body: "Internal Server Error"`, err.Error())
-	})
-}
-
-func TestCollect(t *testing.T) {
-	t.Run("Should collect metrics successfully", func(t *testing.T) {
-		mockHosts := []string{"http://test-host1", "http://test-host2"}
-		config.KafkaConnectHosts = mockHosts
-
-		mockConnectors := []string{"connector1", "connector2"}
-		roundTripper := &mockRoundTripper{
-			roundTripFunc: func(req *http.Request) (*http.Response, error) {
-				response := httptest.NewRecorder()
-
-				if req.URL.Path == "/connectors" {
-					resp, _ := json.Marshal(mockConnectors)
-					response.Write([]byte(resp))
-				} else if req.URL.Path == "/connectors/connector1/status" {
-					response.Write([]byte(`{
-						"name": "connector1",
-						"tasks": [{"state": "RUNNING"}, {"state": "FAILED"}]
-					}`))
-				} else if req.URL.Path == "/connectors/connector2/status" {
-					response.Write([]byte(`{
-						"name": "connector2",
-						"tasks": [{"state": "PAUSED"}]
-					}`))
-				} else {
-					response.WriteHeader(http.StatusNotFound)
-				}
-
-				return response.Result(), nil
-			},
-		}
-
-		collector := New()
-		collector.client = &http.Client{Transport: roundTripper}
-
-		ch := make(chan prometheus.Metric, len(mockHosts)*len(mockConnectors)*5+len(mockHosts))
-		go func() {
-			collector.Collect(ch)
-			close(ch)
-		}()
-
-		var collectedMetrics []prometheus.Metric
-		count := 0
-		for metric := range ch {
-			count++
-			collectedMetrics = append(collectedMetrics, metric)
-		}
-
-		assert.Equal(t, len(mockHosts)*len(mockConnectors)*5+len(mockHosts), len(collectedMetrics))
-	})
-
-	t.Run("Should log errors when API fails", func(t *testing.T) {
-		mockHosts := []string{"http://test-host1"}
-		config.KafkaConnectHosts = mockHosts
-
-		roundTripper := &mockRoundTripper{
-			roundTripFunc: func(req *http.Request) (*http.Response, error) {
-				response := httptest.NewRecorder()
-				response.WriteHeader(http.StatusInternalServerError)
-				response.Write([]byte(`"Internal Server Error"`))
-				return response.Result(), nil
-			},
-		}
-
-		collector := New()
-		collector.client = &http.Client{Transport: roundTripper}
-
-		ch := make(chan prometheus.Metric, 10)
-		go func() {
-			collector.Collect(ch)
-			close(ch)
-		}()
-
-		collected := false
-		for range ch {
-			collected = true
-		}
-
-		assert.False(t, collected)
 	})
 }

--- a/internal/exporter/prometheus/exporter.go
+++ b/internal/exporter/prometheus/exporter.go
@@ -1,0 +1,141 @@
+package exporter
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/collector"
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
+	applicationError "github.com/Ecube-Labs/kafka-connect-exporter/pkg/application-error"
+	"github.com/Ecube-Labs/kafka-connect-exporter/pkg/logger"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// A struct that implements the prometheus.Collector interface.
+// https://github.com/prometheus/client_golang/blob/7b39d0144166aa94cc8ce4125bcb3b0da89aad5e/prometheus/collector.go#L27
+type exporter struct {
+	collector          *collector.Collector
+	descUnassigned     *prometheus.Desc
+	descRunning        *prometheus.Desc
+	descFailed         *prometheus.Desc
+	descPaused         *prometheus.Desc
+	descTaskCount      *prometheus.Desc
+	descConnectorCount *prometheus.Desc
+}
+
+func New(collector *collector.Collector) *exporter {
+	labels := []string{"connector", "host"}
+	prefix := "kafka_connect_connector"
+
+	exporter := &exporter{
+		collector:          collector,
+		descRunning:        prometheus.NewDesc(prefix+"_running_total", "Total number of tasks in the `RUNNING` state", labels, nil),
+		descFailed:         prometheus.NewDesc(prefix+"_failed_total", "Total number of tasks in the `FAILED` state (e.g., due to exceptions reported in status)", labels, nil),
+		descPaused:         prometheus.NewDesc(prefix+"_paused_total", "Total number of paused tasks for the Kafka Connect connector", labels, nil),
+		descUnassigned:     prometheus.NewDesc(prefix+"_unassigned_total", "Total number of tasks in the `Unassigned` state (i.e., not assigned to any worker.)", labels, nil),
+		descTaskCount:      prometheus.NewDesc(prefix+"_task_total", "Total number of tasks for the Kafka Connect connector", labels, nil),
+		descConnectorCount: prometheus.NewDesc(prefix+"_total", "Total number of tasks for the connector.", []string{"host"}, nil),
+	}
+	prometheus.MustRegister(exporter)
+
+	return exporter
+}
+
+// Describe is a no-op, because the Collector dynamically allocates metrics.
+// https://github.com/prometheus/client_golang/blob/v1.9.0/prometheus/Collector.go#L28-L40
+func (e *exporter) Describe(ch chan<- *prometheus.Desc) {}
+
+func (e *exporter) Collect(ch chan<- prometheus.Metric) {
+	var wg sync.WaitGroup
+
+	// collect metrics for each kafka connect host
+	for _, host := range config.KafkaConnectHosts {
+		wg.Add(1)
+
+		go func(h string) {
+			defer wg.Done()
+
+			connectors, err := e.collector.GetConnectors(h)
+			if err != nil {
+				logger.Log("error", applicationError.UnWrap(err).Stack)
+				return
+			}
+			ch <- prometheus.MustNewConstMetric(e.descConnectorCount, prometheus.GaugeValue, float64(len(connectors)), h)
+
+			for _, connector := range connectors {
+				status, err := e.collector.GetConnectorStatus(h, connector)
+				if err != nil {
+					logger.Log("error", applicationError.UnWrap(err).Stack)
+					continue
+				}
+
+				var unAssignedTaskCount int
+				var runningTaskCount int
+				var pausedTaskCount int
+				var failedTaskCount int
+
+				for _, task := range status.Tasks {
+					switch task.State {
+					case "RUNNING":
+						runningTaskCount++
+					case "PAUSED":
+						pausedTaskCount++
+					case "FAILED":
+						failedTaskCount++
+					default:
+						unAssignedTaskCount++
+					}
+				}
+				metric := ConnectorStatusMetric{
+					UnAssignedTaskCount: unAssignedTaskCount,
+					RunningTaskCount:    runningTaskCount,
+					PausedTaskCount:     pausedTaskCount,
+					FailedTaskCount:     failedTaskCount,
+					TotalTaskCount:      len(status.Tasks),
+				}
+
+				ch <- prometheus.MustNewConstMetric(
+					e.descUnassigned,
+					prometheus.GaugeValue,
+					float64(metric.UnAssignedTaskCount),
+					connector, h,
+				)
+
+				ch <- prometheus.MustNewConstMetric(
+					e.descRunning,
+					prometheus.GaugeValue,
+					float64(metric.RunningTaskCount),
+					connector, h,
+				)
+
+				ch <- prometheus.MustNewConstMetric(
+					e.descFailed,
+					prometheus.GaugeValue,
+					float64(metric.FailedTaskCount),
+					connector, h,
+				)
+
+				ch <- prometheus.MustNewConstMetric(
+					e.descPaused,
+					prometheus.GaugeValue,
+					float64(metric.PausedTaskCount),
+					connector, h,
+				)
+
+				ch <- prometheus.MustNewConstMetric(
+					e.descTaskCount,
+					prometheus.GaugeValue,
+					float64(metric.TotalTaskCount),
+					connector, h,
+				)
+			}
+		}(host)
+	}
+
+	wg.Wait()
+}
+
+func (e *exporter) Handler() http.Handler {
+	return promhttp.Handler()
+}

--- a/internal/exporter/prometheus/exporter_test.go
+++ b/internal/exporter/prometheus/exporter_test.go
@@ -1,0 +1,113 @@
+package exporter
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/collector"
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("Should return a new exporter", func(t *testing.T) {
+		collector := collector.New(&http.Client{Transport: &mockRoundTripper{}})
+		exporter := New(collector)
+		assert.NotNil(t, exporter)
+	})
+	t.Run("Should return a exporter implementing the prometheus.Collector interface", func(t *testing.T) {
+		collector := collector.New(&http.Client{Transport: &mockRoundTripper{}})
+		exporter := New(collector)
+		assert.Implements(t, (*prometheus.Collector)(nil), exporter)
+	})
+}
+
+type mockRoundTripper struct {
+	roundTripFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTripFunc(req)
+}
+
+func TestCollect(t *testing.T) {
+	t.Run("Should collect metrics successfully", func(t *testing.T) {
+		mockHosts := []string{"http://test-host1", "http://test-host2"}
+		config.KafkaConnectHosts = mockHosts
+
+		mockConnectors := []string{"connector1", "connector2"}
+		roundTripper := &mockRoundTripper{
+			roundTripFunc: func(req *http.Request) (*http.Response, error) {
+				response := httptest.NewRecorder()
+
+				if req.URL.Path == "/connectors" {
+					resp, _ := json.Marshal(mockConnectors)
+					response.Write([]byte(resp))
+				} else if req.URL.Path == "/connectors/connector1/status" {
+					response.Write([]byte(`{
+						"name": "connector1",
+						"tasks": [{"state": "RUNNING"}, {"state": "FAILED"}]
+					}`))
+				} else if req.URL.Path == "/connectors/connector2/status" {
+					response.Write([]byte(`{
+						"name": "connector2",
+						"tasks": [{"state": "PAUSED"}]
+					}`))
+				} else {
+					response.WriteHeader(http.StatusNotFound)
+				}
+
+				return response.Result(), nil
+			},
+		}
+
+		exporter := New(collector.New(&http.Client{Transport: roundTripper}))
+
+		ch := make(chan prometheus.Metric, len(mockHosts)*len(mockConnectors)*5+len(mockHosts))
+		go func() {
+			exporter.Collect(ch)
+			close(ch)
+		}()
+
+		var collectedMetrics []prometheus.Metric
+		count := 0
+		for metric := range ch {
+			count++
+			collectedMetrics = append(collectedMetrics, metric)
+		}
+
+		assert.Equal(t, len(mockHosts)*len(mockConnectors)*5+len(mockHosts), len(collectedMetrics))
+	})
+
+	t.Run("Should log errors when API fails", func(t *testing.T) {
+		mockHosts := []string{"http://test-host1"}
+		config.KafkaConnectHosts = mockHosts
+
+		roundTripper := &mockRoundTripper{
+			roundTripFunc: func(req *http.Request) (*http.Response, error) {
+				response := httptest.NewRecorder()
+				response.WriteHeader(http.StatusInternalServerError)
+				response.Write([]byte(`"Internal Server Error"`))
+				return response.Result(), nil
+			},
+		}
+
+		exporter := New(collector.New(&http.Client{Transport: roundTripper}))
+
+		ch := make(chan prometheus.Metric, 10)
+		go func() {
+			exporter.Collect(ch)
+			close(ch)
+		}()
+
+		collected := false
+		for range ch {
+			collected = true
+		}
+
+		assert.False(t, collected)
+	})
+}

--- a/internal/exporter/prometheus/types.go
+++ b/internal/exporter/prometheus/types.go
@@ -1,0 +1,10 @@
+package exporter
+
+type ConnectorStatusMetric struct {
+	Name                string
+	UnAssignedTaskCount int
+	RunningTaskCount    int
+	PausedTaskCount     int
+	FailedTaskCount     int
+	TotalTaskCount      int
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,9 +18,9 @@ type Server struct {
 	server *http.Server
 }
 
-func New(addr string) *Server {
+func New(port string) *Server {
 	return &Server{
-		server: &http.Server{Addr: ":" + addr},
+		server: &http.Server{Addr: ":" + port},
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/collector"
+	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
+	exporter "github.com/Ecube-Labs/kafka-connect-exporter/internal/exporter/prometheus"
+	"github.com/Ecube-Labs/kafka-connect-exporter/pkg/logger"
+)
+
+type Server struct {
+	server *http.Server
+}
+
+func New(addr string) *Server {
+	return &Server{
+		server: &http.Server{Addr: ":" + addr},
+	}
+}
+
+func (s *Server) Run() {
+	collector := collector.New(&http.Client{Timeout: 10 * time.Second})
+	exporter := exporter.New(collector)
+
+	http.Handle(config.MetricsEndpoint, exporter.Handler())
+	http.HandleFunc(config.HealthCheckEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Log("error", fmt.Sprintf("HTTP Server Error: %s", err))
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Log("info", "Server is shutting down...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := s.server.Shutdown(shutdownCtx); err != nil {
+		logger.Log("error", fmt.Sprintf("Server Shutdown Error: %s", err))
+	} else {
+		logger.Log("info", "Server has been safely shutdown")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,54 +4,35 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os/signal"
-	"syscall"
-	"time"
 
-	"github.com/Ecube-Labs/kafka-connect-exporter/internal/collector"
-	"github.com/Ecube-Labs/kafka-connect-exporter/internal/config"
-	exporter "github.com/Ecube-Labs/kafka-connect-exporter/internal/exporter/prometheus"
+	applicationError "github.com/Ecube-Labs/kafka-connect-exporter/pkg/application-error"
 	"github.com/Ecube-Labs/kafka-connect-exporter/pkg/logger"
 )
 
 type Server struct {
-	server *http.Server
+	httpServer *http.Server
 }
 
-func New(port string) *Server {
+func New(port string, handler http.Handler) *Server {
 	return &Server{
-		server: &http.Server{Addr: ":" + port},
+		httpServer: &http.Server{
+			Addr:    ":" + port,
+			Handler: handler,
+		},
 	}
 }
 
-func (s *Server) Run() {
-	collector := collector.New(&http.Client{Timeout: 10 * time.Second})
-	exporter := exporter.New(collector)
-
-	http.Handle(config.MetricsEndpoint, exporter.Handler())
-	http.HandleFunc(config.HealthCheckEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	})
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	go func() {
-		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Log("error", fmt.Sprintf("HTTP Server Error: %s", err))
-		}
-	}()
-
-	<-ctx.Done()
-	logger.Log("info", "Server is shutting down...")
-
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := s.server.Shutdown(shutdownCtx); err != nil {
-		logger.Log("error", fmt.Sprintf("Server Shutdown Error: %s", err))
-	} else {
-		logger.Log("info", "Server has been safely shutdown")
+func (s *Server) Run() error {
+	if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return applicationError.New(http.StatusInternalServerError, fmt.Sprintf("Failed to start server: %s", err.Error()), "")
 	}
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		return applicationError.New(http.StatusInternalServerError, fmt.Sprintf("Failed to shutdown server: %s", err.Error()), "")
+	}
+	logger.Log("info", "Server has been safely shutdown")
+	return nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("should instantiate a new server instance", func(t *testing.T) {
+		mux := http.NewServeMux()
+		port := "8080"
+		srv := New(port, mux)
+		assert.NotNil(t, srv, "expected new server instance to be non-nil")
+	})
+}
+
+func TestRun(t *testing.T) {
+	t.Run("should respond with expected content", func(t *testing.T) {
+		mux := http.NewServeMux()
+		testPath := "/test"
+		expectedResponse := "Hello, Test!"
+		mux.HandleFunc(testPath, func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(expectedResponse))
+		})
+
+		port := "8090"
+		addr := "localhost:" + port
+		srv := New(port, mux)
+
+		err := srv.Run()
+		assert.NoError(t, err, "server should start successfully")
+
+		resp, err := http.Get("http://" + addr + testPath)
+		assert.NoError(t, err, "GET request should succeed")
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		assert.NoError(t, err, "should be able to read response body")
+		assert.Equal(t, expectedResponse, string(body), "response should match")
+	})
+}
+
+func TestShutdown(t *testing.T) {
+	mux := http.NewServeMux()
+	testPath := "/shutdown"
+	mux.HandleFunc(testPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Shutdown Test"))
+	})
+
+	port := "8091"
+	addr := "localhost:" + port
+	srv := New(port, mux)
+
+	err := srv.Run()
+	assert.NoError(t, err, "server should start successfully")
+
+	t.Run("should shutdown the server gracefully", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		err := srv.Shutdown(ctx)
+		assert.NoError(t, err, "server shutdown should succeed")
+	})
+
+	t.Run("should refuse connection after shutdown", func(t *testing.T) {
+		_, err := http.Get("http://" + addr + testPath)
+		assert.Error(t, err, "expected error when connecting to shutdown server")
+	})
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,8 +32,13 @@ func TestRun(t *testing.T) {
 		addr := "localhost:" + port
 		srv := New(port, mux)
 
-		err := srv.Run()
-		assert.NoError(t, err, "server should start successfully")
+		go func() {
+			err := srv.Run()
+			if err != nil && err != http.ErrServerClosed {
+				t.Logf("server error: %v", err)
+			}
+		}()
+		time.Sleep(100 * time.Millisecond)
 
 		resp, err := http.Get("http://" + addr + testPath)
 		assert.NoError(t, err, "GET request should succeed")
@@ -55,8 +60,13 @@ func TestShutdown(t *testing.T) {
 	addr := "localhost:" + port
 	srv := New(port, mux)
 
-	err := srv.Run()
-	assert.NoError(t, err, "server should start successfully")
+	go func() {
+		err := srv.Run()
+		if err != nil && err != http.ErrServerClosed {
+			t.Logf("server error: %v", err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
 
 	t.Run("should shutdown the server gracefully", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

- Separate collector and exporter logic
  - collector only collect kafka connect statuses
  - exporter only export metrics
- make server struct 
  - simplify main function
  - adapt graceful shutdown
  - http server logic is server struct responsibility

<!-- Issue number if applicable -->
#### Link to tracking issue

Resolves #9 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- test collector and exporter

<!--Describe the documentation added.-->
#### Documentation
- modify docker compose example
  - [docker compose version is obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete)

<!--Please delete paragraphs that you did not use before submitting.-->
